### PR TITLE
Return CSV data in CLARIOstar StartRead gRPC reply

### DIFF
--- a/tools/clariostar/server.py
+++ b/tools/clariostar/server.py
@@ -3,6 +3,7 @@ import logging
 
 from tools.base_server import ToolServer, serve
 from tools.grpc_interfaces.clariostar_pb2 import Command, Config
+from tools.grpc_interfaces.tool_base_pb2 import ExecuteCommandReply, SUCCESS
 
 from .driver import CLARIOstarDriver
 
@@ -41,13 +42,17 @@ class ClariostarServer(ToolServer):
     def CloseCarrier(self, params: Command.CloseCarrier) -> None:
         self.driver.plate_in()
 
-    def StartRead(self, params: Command.StartRead) -> None:
-        self.driver.run_protocol(
+    def StartRead(self, params: Command.StartRead) -> ExecuteCommandReply:
+        data = self.driver.run_protocol(
             protocol_name=params.protocol_name,
             plate_id=params.plate_id,
             assay_id=params.assay_id,
             timepoint=params.timepoint,
         )
+        response = ExecuteCommandReply(response=SUCCESS, return_reply=True)
+        if data:
+            response.meta_data.update({"data": data})
+        return response
 
     def SetTemperature(self, params: Command.SetTemperature) -> None:
         self.driver.set_temperature(temperature=params.temperature)


### PR DESCRIPTION
## Summary
- CLARIOstar `StartRead` now returns the CSV content from `run_protocol()` in the `ExecuteCommandReply.meta_data` field
- Previously the CSV data was discarded (method returned `None`)
- This makes measurement data available to upstream consumers (e.g., webhook integrations in galago-core)

## Details
The `base_server.py` `_dispatchCommand` method already handles non-None responses correctly — it copies `response`, `meta_data`, `error_message`, and `return_reply` from the returned object. This change simply returns the reply object instead of `None`.

## Test plan
- [ ] Verify CLARIOstar server imports cleanly
- [ ] Verify StartRead returns CSV data in `meta_data.data` field when run in simulated mode
- [ ] Verify existing CLARIOstar functionality is unaffected (OpenCarrier, CloseCarrier, SetTemperature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)