### PR TITLE
fix(pf400): restore monitor speed on init + expose speed control

### DIFF
--- a/interfaces/tools/grpc_interfaces/pf400.proto
+++ b/interfaces/tools/grpc_interfaces/pf400.proto
@@ -24,6 +24,19 @@ message Command {
     RegisterMotionProfile register_motion_profile = 17;
     LoadWaypoints load_waypoints = 18;
     LoadLabware load_labware =19;
+    SetSpeed set_speed = 20;
+    GetSpeed get_speed = 21;
+  }
+
+  // Sets the robot's global monitor speed (mspeed), a 1-100 governor that
+  // scales the effective speed of every motion. This is the value a teach
+  // pendant speed slider drives.
+  message SetSpeed {
+    int32 speed = 1;
+  }
+
+  // Returns the current global monitor speed (mspeed) in reply meta_data.
+  message GetSpeed {
   }
 
   message RawCommand {
@@ -133,4 +146,8 @@ message Config {
   int32 port = 2;
   int32 joints = 3;
   string gpl_version = 4;
+  // Global monitor speed (mspeed, 1-100) applied on initialization so the arm
+  // never inherits a stale, low governor left behind by manual/pendant use.
+  // Defaults to 100 when unset (0).
+  int32 system_speed = 5;
 }

--- a/tools/pf400/driver.py
+++ b/tools/pf400/driver.py
@@ -31,6 +31,10 @@ class RobotConfig:
     grasp_plate_buffer_mm: int = 10
     joints: int = 5
     gpl_version: str = "v1"
+    # Global monitor speed (mspeed, 1-100) applied on initialization. The PF400
+    # scales every motion by this governor, so a low value left behind by manual
+    # or teach-pendant use makes all automated moves slow. Default 100.
+    system_speed: int = 100
 
 @dataclass
 class Location:
@@ -180,9 +184,31 @@ class RobotInitializer:
             self._ensure_power_on()
             self._ensure_robot_attached()
             self._ensure_robot_homed()
+            self._ensure_system_speed()
         except Exception as e:
             logging.error(f"Initialization failed: {e}")
             raise
+
+    def _ensure_system_speed(self) -> None:
+        """Restore the global monitor speed (mspeed) governor.
+
+        The PF400 scales every motion by mspeed (1-100). Manual jogging or
+        teaching commonly leaves it low, which then silently slows every
+        automated move. We reset it to the configured value (default 100) on
+        every initialization so behavior is deterministic regardless of how the
+        arm was last used.
+        """
+        target = self.config.system_speed
+        if not target or target <= 0:
+            target = 100
+        target = max(1, min(100, target))
+        try:
+            previous = self.communicator.send_command("mspeed")
+            self.communicator.send_command(f"mspeed {target}")
+            logging.info(f"Set system monitor speed (mspeed) to {target} (was {previous})")
+        except Exception as e:
+            # Non-fatal: a bad governor slows the arm but should not block startup.
+            logging.warning(f"Could not set system monitor speed to {target}: {e}")
 
     def _ensure_pc_mode(self) -> None:
         """Ensure robot is in PC mode"""
@@ -283,9 +309,9 @@ class RobotInitializer:
 
 class Pf400Driver(ABCToolDriver):
     """Main driver class for the PF400 robot"""
-    def __init__(self, tcp_host: str, tcp_port: int, joints:int=5, gpl_version:str="v1") -> None:
+    def __init__(self, tcp_host: str, tcp_port: int, joints:int=5, gpl_version:str="v1", system_speed:int=100) -> None:
         self.state = RobotState()
-        self.config = RobotConfig(tcp_host=tcp_host, tcp_port=tcp_port, joints=joints, gpl_version=gpl_version)
+        self.config = RobotConfig(tcp_host=tcp_host, tcp_port=tcp_port, joints=joints, gpl_version=gpl_version, system_speed=system_speed)
         self.tcp_ip: Optional[Pf400TcpIp] = None
         self.communicator: Optional[RobotCommunicator] = None 
         self.gripper: Optional[GripperController] = None

--- a/tools/pf400/server.py
+++ b/tools/pf400/server.py
@@ -54,6 +54,23 @@ DEFAULT_MOTION_PROFILES : list[MotionProfile] = [
         inrange=0,
         straight=1
     ),
+    #transit profile: negative inrange enables continuous-path blending so the
+    #arm does not decelerate to a full stop at intermediate approach waypoints.
+    #Intended for the fast point-to-point legs of a move; use "default"/
+    #"default_straight" (inrange=0) for the final approach/place segment where
+    #the arm must settle precisely on target.
+    MotionProfile(
+        name="transit",
+        id=3,
+        speed=100,
+        speed2=100,
+        acceleration=100,
+        deceleration=100,
+        accel_ramp=0.1,
+        decel_ramp=0.1,
+        inrange=-1,
+        straight=0
+    ),
 ]
 
 
@@ -92,7 +109,7 @@ class Pf400Server(ToolServer):
             tcp_port=request.port,
             joints=request.joints,
             gpl_version=request.gpl_version,
-
+            system_speed=(getattr(request, "system_speed", 100) or 100),
         )
         self.driver.initialize()
 
@@ -571,6 +588,33 @@ class Pf400Server(ToolServer):
             response.error_message = str(e)
             return response
 
+    def SetSpeed(self, params: Command.SetSpeed) -> None:
+        """Set the global monitor speed (mspeed) governor, 1-100."""
+        if not self.driver:
+            raise Exception("Driver not initialized")
+        speed = max(1, min(100, params.speed))
+        self.driver.set_sys_speed(speed)
+
+    def GetSpeed(self, params: Command.GetSpeed) -> ExecuteCommandReply:
+        """Return the current global monitor speed (mspeed) in meta_data."""
+        response = ExecuteCommandReply()
+        response.return_reply = True
+        response.response = SUCCESS
+        try:
+            if not self.driver:
+                raise Exception("Driver not initialized")
+            # mspeed returns "0 <value>"; expose the raw reply.
+            speed = self.driver.get_sys_speed()
+            meta = Struct()
+            meta.update({"speed": speed})
+            response.meta_data.CopyFrom(meta)
+            return response
+        except Exception as e:
+            logging.error(f"Error getting system speed: {e}")
+            response.response = ERROR_FROM_TOOL
+            response.error_message = str(e)
+            return response
+
     def command_instance_from_name(self, command_name: str) -> Union[message.Message, t.Any]:
         command_descriptors = Command.DESCRIPTOR.fields_by_name
         command_dictionary = dict()
@@ -643,6 +687,12 @@ class Pf400Server(ToolServer):
         return 1 
     
     def EstimateLoadLabware(self, params: Command.LoadLabware) -> int:
+        return 1
+
+    def EstimateSetSpeed(self, params: Command.SetSpeed) -> int:
+        return 1
+
+    def EstimateGetSpeed(self, params: Command.GetSpeed) -> int:
         return 1
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why the PF400 was moving slowly

The PF400 scales **every** motion by its global monitor speed `mspeed` (a 1–100 governor). The driver had `set_sys_speed`/`get_sys_speed` defined but **never called anywhere** — so the arm ran at whatever `mspeed` the last manual jog / teach-pendant session left behind (commonly 10–30%), silently slowing all automated moves.

## Changes

- **`driver.py` — the fix:** `_ensure_system_speed()` runs on every `initialize()` and sets `mspeed` to a configured value (default **100**), clamped to 1–100. Non-fatal if it fails, so a bad governor can't block startup. Logs previous → new value.
- **`pf400.proto` / `RobotConfig`:** new `system_speed` config field (default 100; unset/0 → 100).
- **`server.py`:** wires `system_speed` into the driver; adds `SetSpeed` / `GetSpeed` gRPC commands (+ `Estimate*` for sim mode) so a teach-pendant **speed slider** can drive `mspeed` live.
- **`server.py`:** adds a `transit` default motion profile (`inrange=-1`) enabling continuous-path blending on fast point-to-point legs — groundwork; approach/place keep `inrange=0` profiles for precise settling.

## Validation

- Proto compiles and generates the new symbols.
- Stubbed checks pass: `mspeed` clamping/default (0→100, 250→100, 30→30), `SetSpeed` clamping (150→100, 0→1), `GetSpeed` meta_data, transit profile (`inrange=-1`).
- Not exercised against hardware — please verify on the arm, starting at low speed.

## Notes / follow-ups

- Generated `*_pb2` are gitignored (built at install) — **rebuild the package** for the server to pick up `Config.system_speed` and the new commands. Takes effect on next tool `Configure`/`initialize`.
- The `transit` profile is **not yet wired into sequences** (prod loads profiles from the Galago DB); applying blending to transit legs is a follow-up needing hardware tuning.
- The C# `device-controllers` PF400 init has the same omission (`Robot.cs` has `mspeed` plumbing but doesn't set it) — same one-line fix applies.

This is **Phase 1** of a larger PF400 / teach-pendant plan (jog overhaul, safety/recovery commands, richer status + teaching, pendant UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)